### PR TITLE
Fix build error when compiled on Tinker board

### DIFF
--- a/drivers/net/wireless/rockchip_wlan/rtl8723bs/hal/hal_mp.c
+++ b/drivers/net/wireless/rockchip_wlan/rtl8723bs/hal/hal_mp.c
@@ -1073,7 +1073,7 @@ void mpt_SetRFPath_8723B(PADAPTER pAdapter)
 	}
 
 	switch (pAdapter->mppriv.antenna_tx) {
-		u8 p = 0, i = 0;
+		u8 p, i;
 	case ANTENNA_A: { /*/ Actually path S1  (Wi-Fi)*/
 		pMptCtx->mpt_rf_path = ODM_RF_PATH_A;
 		phy_set_bb_reg(pAdapter, rS0S1_PathSwitch, BIT9 | BIT8 | BIT7, 0x0);


### PR DESCRIPTION
drivers/net/wireless/rockchip_wlan/rtl8723bs/hal/hal_mp.c:1076:6: warning: statement will never be executed [-Wswitch-unreachable]
error, forbidden warning: hal_mp.c:1076