### PR TITLE
Eliminate noise at the start of DSD playback.

### DIFF
--- a/sound/usb/endpoint.c
+++ b/sound/usb/endpoint.c
@@ -642,8 +642,23 @@ static int data_ep_set_params(struct snd_usb_endpoint *ep,
 
 	ep->datainterval = fmt->datainterval;
 	ep->stride = frame_bits >> 3;
-	ep->silence_value = pcm_format == SNDRV_PCM_FORMAT_U8 ? 0x80 : 0;
-
+	
+	
+	switch (pcm_format) {
+ 	case SNDRV_PCM_FORMAT_U8:
+ 		ep->silence_value = 0x80;
+ 		break;
+ 	case SNDRV_PCM_FORMAT_DSD_U8:
+ 	case SNDRV_PCM_FORMAT_DSD_U16_LE:
+ 	case SNDRV_PCM_FORMAT_DSD_U32_LE:
+ 	case SNDRV_PCM_FORMAT_DSD_U16_BE:
+ 	case SNDRV_PCM_FORMAT_DSD_U32_BE:
+ 		ep->silence_value = 0x69;
+ 		break;
+ 	default:
+ 		ep->silence_value = 0;
+ 	}
+	
 	/* assume max. frequency is 25% higher than nominal */
 	ep->freqmax = ep->freqn + (ep->freqn >> 2);
 	/* Round up freqmax to nearest integer in order to calculate maximum


### PR DESCRIPTION
ALSA: usb-audio: Eliminate noise at the start of DSD playback.
Copy mainline DSD playback pop noise fix

torvalds@0120073#diff-cc9fc192670bbec31122ad6874641755

[Problem]
In some USB DACs, a terrible pop noise comes to be heard
at the start of DSD playback (in the following situations).

- play first DSD track
- change from PCM track to DSD track
- change from DSD64 track to DSD128 track (and etc...)
- seek DSD track
- Fast-Forward/Rewind DSD track

[Cause]
At the start of playback, there is a little silence.
The silence bit pattern "0x69" is required on DSD mode,
but it is not like that.

[Solution]
This patch adds DSD silence pattern to the endpoint settings.

Signed-off-by: Nobutaka Okabe <nob77413@gmail.com>
Signed-off-by: Takashi Iwai <tiwai@suse.de>