### PR TITLE
ALSA: usb-audio: Add Gustard U16/X26 to quirks for native DSD support

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1317,6 +1317,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
         case USB_ID(0x2622, 0x0666): /* QUAD Artera */
         case USB_ID(0x25ce, 0x001f): /* Mytek Brooklyn DAC */
         case USB_ID(0x22d9, 0x0436): /* OPPO Sonica */
+	case USB_ID(0x292b, 0xc4b3): /* Gustard U16/X26 USB Interface */
                 if (fp->altsetting == 2)
                         return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 		break;


### PR DESCRIPTION
ALSA: usb-audio: Add Gustard U16/X26 to quirks for native DSD support