### PR TITLE
fix build error driver qmi_wwan with gcc 7.5

### DIFF
--- a/drivers/net/usb/qmi_wwan.c
+++ b/drivers/net/usb/qmi_wwan.c
@@ -30,7 +30,9 @@ struct sk_buff *qmi_wwan_tx_fixup(struct usbnet *dev, struct sk_buff *skb, gfp_t
 	if (dev->net->hard_header_len == 0)
 		return skb;
 	else
-		skb_reset_mac_header(skb); if (skb_pull(skb, ETH_HLEN)) {
+		skb_reset_mac_header(skb);
+
+	if (skb_pull(skb, ETH_HLEN)) {
 		return skb;
 	} else {
 		dev_err(&dev->intf->dev, "Packet Dropped ");


### PR DESCRIPTION
Compile error when I build from source the Linux kernel source on Host Ubuntu 20.04 + arm-linux-hf-gcc linaro 7.5